### PR TITLE
chore: propagate parsing error messages to plugin logs

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -66,8 +66,8 @@ export function setupPlugin({ global, config, attachments }: PluginMeta) {
       }
       // Save the filters to the global object
       global.filters = filters;
-    } catch {
-      throw new Error("Could not parse filters attachment");
+    } catch (err) {
+      throw new Error("Could not parse filters attachment: " + err.message);
     }
   } else {
     global.filters = [];


### PR DESCRIPTION
Right now, the exception is swallowed and the users need to guess what is invalid in their config.

This PR concatenates `err.message` as I could not get the new `throw new Error('message', { cause: err })` syntax to work on node 18 