### PR TITLE
Fix typo in example configuration in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ Only keep events where all the following conditions are met:
     "value": "yourcompany.com"
   },
   {
-    "property": "host",
+    "property": "$host",
     "type": "string",
     "operator": "is_not",
     "value": "localhost:8000"
   },
   {
-    "property": "browser_version",
+    "property": "$browser_version",
     "type": "number",
     "operator": "gt",
     "value": 100


### PR DESCRIPTION
This PR brings the example in `README.md` up to date with the example in https://posthog.com/tutorials/fewer-unwanted-events#filter-out-app

Also tested it out manually with `lib` vs `$lib`.