### PR TITLE
update example

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ Only keep events where all the following conditions are met:
     "value": "yourcompany.com"
   },
   {
-    "property": "host",
+    "property": "$host",
     "type": "string",
     "operator": "is_not",
     "value": "localhost:8000"
   },
   {
-    "property": "browser_version",
+    "property": "$browser_version",
     "type": "number",
     "operator": "gt",
     "value": 100


### PR DESCRIPTION
The actual posthog properties are called `$host` or `$browser_version`.

https://posthoghelp.zendesk.com/agent/tickets/9008