### PR TITLE
feat: support OR in filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ This plugin configuration requires a JSON file containing an array of filter gro
 
 **1. Single Filter Group:**  
 To keep events where all the following conditions are met:
-- **Email** does _not contain_ **yourcompany.com**
-- **Host** is _not_ **localhost:8000**
-- **Browser version** is _greater than_ **100**
+- **Email** _does not contain_ **yourcompany.com**
+- **Host** _is not_ **localhost:8000**
+- **Browser version** _is greater than_ **100**
 
 ```json
 [

--- a/README.md
+++ b/README.md
@@ -1,43 +1,86 @@
 # 🦔 PostHog Filter Out Plugin
 
-> Injest only those events satisfying the given filter conditions
+> Ingest only those events satisfying the given filter conditions.
 
 ## Configuration
 
-The plugin configuration requires a JSON file with the following structure:
+This plugin configuration requires a JSON file containing an array of filter groups. Events matching **any** filter group will be kept, meaning there's an OR logic between groups. However, within each filter group, **all** conditions must be met (AND logic).
 
-**Example filters:**
+**Example Filters:**
 
-Only keep events where all the following conditions are met:
-
-- **Email** _does not contain_ **yourcompany.com**
-- **Host** _is not_ **localhost:8000**
-- **Browser version** _greater than_ **100**
+**1. Single Filter Group:**  
+To keep events where all the following conditions are met:
+- **Email** does _not contain_ **yourcompany.com**
+- **Host** is _not_ **localhost:8000**
+- **Browser version** is _greater than_ **100**
 
 ```json
 [
-  {
-    "property": "email",
-    "type": "string",
-    "operator": "not_contains",
-    "value": "yourcompany.com"
-  },
-  {
-    "property": "$host",
-    "type": "string",
-    "operator": "is_not",
-    "value": "localhost:8000"
-  },
-  {
-    "property": "$browser_version",
-    "type": "number",
-    "operator": "gt",
-    "value": 100
-  }
+  [
+    {
+      "property": "email",
+      "type": "string",
+      "operator": "not_contains",
+      "value": "yourcompany.com"
+    },
+    {
+      "property": "$host",
+      "type": "string",
+      "operator": "is_not",
+      "value": "localhost:8000"
+    },
+    {
+      "property": "$browser_version",
+      "type": "number",
+      "operator": "gt",
+      "value": 100
+    }
+  ]
 ]
 ```
 
-**Allowed types and their operators:**
+**2. Multiple Filter Groups (OR Logic):**  
+To keep events where:
+- **Group 1:** The **Email** does _not contain_ **yourcompany.com** and the **Host** is _not_ **localhost:8000**  
+- OR
+- **Group 2:** The **Event Type** is **signup** and the **Browser** is **Chrome**
+
+```json
+[
+  [
+    {
+      "property": "email",
+      "type": "string",
+      "operator": "not_contains",
+      "value": "yourcompany.com"
+    },
+    {
+      "property": "$host",
+      "type": "string",
+      "operator": "is_not",
+      "value": "localhost:8000"
+    }
+  ],
+  [
+    {
+      "property": "$event_type",
+      "type": "string",
+      "operator": "is",
+      "value": "signup"
+    },
+    {
+      "property": "$browser",
+      "type": "string",
+      "operator": "is",
+      "value": "Chrome"
+    }
+  ]
+]
+```
+
+In this configuration, an event will be retained if it matches **any** of the specified groups.
+
+### Allowed Types and Their Operators
 
 | Type    | Operators                                            |
 | ------- | ---------------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ To keep events where all the following conditions are met:
 
 **2. Multiple Filter Groups (OR Logic):**  
 To keep events where:
-- **Group 1:** The **Email** does _not contain_ **yourcompany.com** and the **Host** is _not_ **localhost:8000**  
+- **Group 1:** **Email** _does not contain_ **yourcompany.com** and **Host** _is not_ **localhost:8000**  
 - OR
-- **Group 2:** The **Event Type** is **signup** and the **Browser** is **Chrome**
+- **Group 2:** **Event Type** _is_ **signup** and **Browser** _is_ **Chrome**
 
 ```json
 [

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -2,8 +2,7 @@ import { expect, test, describe } from "@jest/globals";
 import { createEvent } from "@posthog/plugin-scaffold/test/utils";
 import { Filter, PluginMeta, processEvent, setupPlugin } from "./main";
 
-const filters: Filter[][] = [
-    [
+const filters: Filter[] = [
         {
             property: "$host",
             type: "string",
@@ -22,7 +21,6 @@ const filters: Filter[][] = [
             operator: "is",
             value: true,
         },
-    ],
 ];
 
 const meta = {

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -5,24 +5,24 @@ import { PluginEvent } from "@posthog/plugin-scaffold";
 import { Filter, PluginMeta, processEvent, setupPlugin } from "./main";
 
 const filters: Filter[] = [
-        {
-            property: "$host",
-            type: "string",
-            operator: "not_contains",
-            value: "localhost",
-        },
-        {
-            property: "foo",
-            type: "number",
-            operator: "gt",
-            value: 10,
-        },
-        {
-            property: "bar",
-            type: "boolean",
-            operator: "is",
-            value: true,
-        },
+    {
+        property: "$host",
+        type: "string",
+        operator: "not_contains",
+        value: "localhost",
+    },
+    {
+        property: "foo",
+        type: "number",
+        operator: "gt",
+        value: 10,
+    },
+    {
+        property: "bar",
+        type: "boolean",
+        operator: "is",
+        value: true,
+    },
 ];
 
 const meta = {

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -3,250 +3,250 @@ import { createEvent } from "@posthog/plugin-scaffold/test/utils";
 import { Filter, PluginMeta, processEvent, setupPlugin } from "./main";
 
 const filters: Filter[][] = [
-  [
-    {
-      property: "$host",
-      type: "string",
-      operator: "not_contains",
-      value: "localhost",
-    },
-    {
-      property: "foo",
-      type: "number",
-      operator: "gt",
-      value: 10,
-    },
-    {
-      property: "bar",
-      type: "boolean",
-      operator: "is",
-      value: true,
-    },
-  ],
+    [
+        {
+            property: "$host",
+            type: "string",
+            operator: "not_contains",
+            value: "localhost",
+        },
+        {
+            property: "foo",
+            type: "number",
+            operator: "gt",
+            value: 10,
+        },
+        {
+            property: "bar",
+            type: "boolean",
+            operator: "is",
+            value: true,
+        },
+    ],
 ];
 
 const meta = {
-  global: { filters, eventsToDrop: ["to_drop_event"] },
+    global: { filters, eventsToDrop: ["to_drop_event"] },
 } as PluginMeta;
 
 test("Event satisfies all conditions and passes", () => {
-  const event = createEvent({
-    event: "test event",
-    properties: {
-      $host: "example.com",
-      foo: 20,
-      bar: true,
-    },
-  });
-  const processedEvent = processEvent(event, meta);
-  expect(processedEvent).toEqual(event);
+    const event = createEvent({
+        event: "test event",
+        properties: {
+            $host: "example.com",
+            foo: 20,
+            bar: true,
+        },
+    });
+    const processedEvent = processEvent(event, meta);
+    expect(processedEvent).toEqual(event);
 });
 
 test("Event does not satisfy one condition and is dropped", () => {
-  const event = createEvent({
-    event: "test event",
-    properties: {
-      $host: "localhost:8000",
-      foo: 20,
-      bar: true,
-    },
-  });
-  const processedEvent = processEvent(event, meta);
-  expect(processedEvent).toBeUndefined();
+    const event = createEvent({
+        event: "test event",
+        properties: {
+            $host: "localhost:8000",
+            foo: 20,
+            bar: true,
+        },
+    });
+    const processedEvent = processEvent(event, meta);
+    expect(processedEvent).toBeUndefined();
 });
 
 test("Event does not satisfy any condition and is dropped", () => {
-  const event = createEvent({
-    event: "test event",
-    properties: {
-      $host: "localhost:8000",
-      foo: 5,
-      bar: false,
-    },
-  });
-  const processedEvent = processEvent(event, meta);
-  expect(processedEvent).toBeUndefined();
+    const event = createEvent({
+        event: "test event",
+        properties: {
+            $host: "localhost:8000",
+            foo: 5,
+            bar: false,
+        },
+    });
+    const processedEvent = processEvent(event, meta);
+    expect(processedEvent).toBeUndefined();
 });
 
 test("Event is marked to be dropped is dropped", () => {
-  const event = createEvent({
-    event: "to_drop_event",
-    properties: {
-      $host: "example.com",
-      foo: 20,
-      bar: true,
-    },
-  });
-  const processedEvent = processEvent(event, meta);
-  expect(processedEvent).toBeUndefined();
+    const event = createEvent({
+        event: "to_drop_event",
+        properties: {
+            $host: "example.com",
+            foo: 20,
+            bar: true,
+        },
+    });
+    const processedEvent = processEvent(event, meta);
+    expect(processedEvent).toBeUndefined();
 });
 
 test("Event is marked to be dropped when a property is undefined", () => {
-  const event = createEvent({
-    event: "test_event",
-    properties: {
-      $host: undefined,
-      foo: 20,
-      bar: true,
-    },
-  });
-  const processedEvent = processEvent(event, meta);
-  expect(processedEvent).toBeUndefined();
+    const event = createEvent({
+        event: "test_event",
+        properties: {
+            $host: undefined,
+            foo: 20,
+            bar: true,
+        },
+    });
+    const processedEvent = processEvent(event, meta);
+    expect(processedEvent).toBeUndefined();
 });
 
 test("Event is marked to be dropped when a property is undefined but keepUndefinedProperties", () => {
-  const event = createEvent({
-    event: "test_event",
-    properties: {
-      $host: undefined,
-      foo: 20,
-      bar: true,
-    },
-  });
-  const processedEvent = processEvent(event, {
-    global: { ...meta.global, keepUndefinedProperties: true },
-  } as PluginMeta);
-  expect(processedEvent).toEqual(event);
+    const event = createEvent({
+        event: "test_event",
+        properties: {
+            $host: undefined,
+            foo: 20,
+            bar: true,
+        },
+    });
+    const processedEvent = processEvent(event, {
+        global: { ...meta.global, keepUndefinedProperties: true },
+    } as PluginMeta);
+    expect(processedEvent).toEqual(event);
 });
 
 function setup(config) {
-  const global: any = {};
+    const global: any = {};
 
-  setupPlugin({
-    config,
-    global,
-    attachments: { filters: { contents: JSON.stringify(filters) } },
-  } as any);
+    setupPlugin({
+        config,
+        global,
+        attachments: { filters: { contents: JSON.stringify(filters) } },
+    } as any);
 
-  return global;
+    return global;
 }
 
 test("setupPlugin() parsing eventsToDrop", () => {
-  expect(setup({ eventsToDrop: "foo, bar  " }).eventsToDrop).toEqual([
-    "foo",
-    "bar",
-  ]);
-  expect(setup({ eventsToDrop: "$foo,$bar" }).eventsToDrop).toEqual([
-    "$foo",
-    "$bar",
-  ]);
-  expect(setup({}).eventsToDrop).toEqual([]);
+    expect(setup({ eventsToDrop: "foo, bar  " }).eventsToDrop).toEqual([
+        "foo",
+        "bar",
+    ]);
+    expect(setup({ eventsToDrop: "$foo,$bar" }).eventsToDrop).toEqual([
+        "$foo",
+        "$bar",
+    ]);
+    expect(setup({}).eventsToDrop).toEqual([]);
 });
 
 test("setupPlugin() parsing keepUndefinedProperties", () => {
-  expect(
-    setup({ keepUndefinedProperties: "Yes" }).keepUndefinedProperties
-  ).toEqual(true);
-  expect(
-    setup({ keepUndefinedProperties: "No" }).keepUndefinedProperties
-  ).toEqual(false);
-  expect(setup({}).keepUndefinedProperties).toEqual(false);
+    expect(
+        setup({ keepUndefinedProperties: "Yes" }).keepUndefinedProperties
+    ).toEqual(true);
+    expect(
+        setup({ keepUndefinedProperties: "No" }).keepUndefinedProperties
+    ).toEqual(false);
+    expect(setup({}).keepUndefinedProperties).toEqual(false);
 });
 
 describe("empty filters", () => {
-  const meta_no_filters = {
-    global: { filters: [], eventsToDrop: ["to_drop_event"] },
-  } as PluginMeta;
+    const meta_no_filters = {
+        global: { filters: [], eventsToDrop: ["to_drop_event"] },
+    } as PluginMeta;
 
-  test("Event satisfies all conditions and passes", () => {
-    const event = createEvent({
-      event: "test event",
-      properties: {
-        $host: "example.com",
-        foo: 20,
-        bar: true,
-      },
+    test("Event satisfies all conditions and passes", () => {
+        const event = createEvent({
+            event: "test event",
+            properties: {
+                $host: "example.com",
+                foo: 20,
+                bar: true,
+            },
+        });
+        const processedEvent = processEvent(event, meta_no_filters);
+        expect(processedEvent).toEqual(event);
     });
-    const processedEvent = processEvent(event, meta_no_filters);
-    expect(processedEvent).toEqual(event);
-  });
 
-  test("Event is marked to be dropped is dropped", () => {
-    const event = createEvent({
-      event: "to_drop_event",
-      properties: {
-        $host: "example.com",
-        foo: 20,
-        bar: true,
-      },
+    test("Event is marked to be dropped is dropped", () => {
+        const event = createEvent({
+            event: "to_drop_event",
+            properties: {
+                $host: "example.com",
+                foo: 20,
+                bar: true,
+            },
+        });
+        const processedEvent = processEvent(event, meta_no_filters);
+        expect(processedEvent).toBeUndefined();
     });
-    const processedEvent = processEvent(event, meta_no_filters);
-    expect(processedEvent).toBeUndefined();
-  });
 
-  test("setupPlugin() without any config works", () => {
-    const global: any = {};
-    setupPlugin({ config: {}, global, attachments: { filters: null } } as any);
-    expect(global.filters).toEqual([]);
-    expect(global.eventsToDrop).toEqual([]);
-    expect(global.keepUndefinedProperties).toEqual(false);
-  });
+    test("setupPlugin() without any config works", () => {
+        const global: any = {};
+        setupPlugin({ config: {}, global, attachments: { filters: null } } as any);
+        expect(global.filters).toEqual([]);
+        expect(global.eventsToDrop).toEqual([]);
+        expect(global.keepUndefinedProperties).toEqual(false);
+    });
 
-  test("setupPlugin() with other config works", () => {
-    const global: any = {};
-    setupPlugin({
-      config: { eventsToDrop: "foo,bar", keepUndefinedProperties: "Yes" },
-      global,
-      attachments: { filters: null },
-    } as any);
-    expect(global.filters).toEqual([]);
-    expect(global.eventsToDrop).toEqual(["foo", "bar"]);
-    expect(global.keepUndefinedProperties).toEqual(true);
-  });
+    test("setupPlugin() with other config works", () => {
+        const global: any = {};
+        setupPlugin({
+            config: { eventsToDrop: "foo,bar", keepUndefinedProperties: "Yes" },
+            global,
+            attachments: { filters: null },
+        } as any);
+        expect(global.filters).toEqual([]);
+        expect(global.eventsToDrop).toEqual(["foo", "bar"]);
+        expect(global.keepUndefinedProperties).toEqual(true);
+    });
 });
 
 
 const filters_or: Filter[][] = [
-  [
-    {
-      property: "$host",
-      type: "string",
-      operator: "not_contains",
-      value: "localhost",
-    },
-    {
-      property: "foo",
-      type: "number",
-      operator: "gt",
-      value: 10,
-    },
-  ],
-  [
-    {
-      property: "bar",
-      type: "boolean",
-      operator: "is",
-      value: true,
-    },
-  ],
+    [
+        {
+            property: "$host",
+            type: "string",
+            operator: "not_contains",
+            value: "localhost",
+        },
+        {
+            property: "foo",
+            type: "number",
+            operator: "gt",
+            value: 10,
+        },
+    ],
+    [
+        {
+            property: "bar",
+            type: "boolean",
+            operator: "is",
+            value: true,
+        },
+    ],
 ];
 
 const meta_or = {
-  global: { filters: filters_or, eventsToDrop: ["to_drop_event"] },
+    global: { filters: filters_or, eventsToDrop: ["to_drop_event"] },
 } as PluginMeta;
 
 test("Event satisfies at least one filter group and passes", () => {
-  const event = createEvent({
-    event: "test event",
-    properties: {
-      $host: "example.com",
-      foo: 5,
-      bar: true,
-    },
-  });
-  const processedEvent = processEvent(event, meta_or);
-  expect(processedEvent).toEqual(event);
+    const event = createEvent({
+        event: "test event",
+        properties: {
+            $host: "example.com",
+            foo: 5,
+            bar: true,
+        },
+    });
+    const processedEvent = processEvent(event, meta_or);
+    expect(processedEvent).toEqual(event);
 });
 
 test("Event satisfies no filter groups and is dropped", () => {
-  const event = createEvent({
-    event: "test event",
-    properties: {
-      $host: "localhost:8000",
-      foo: 5,
-      bar: false,
-    },
-  });
-  const processedEvent = processEvent(event, meta_or);
-  expect(processedEvent).toBeUndefined();
+    const event = createEvent({
+        event: "test event",
+        properties: {
+            $host: "localhost:8000",
+            foo: 5,
+            bar: false,
+        },
+    });
+    const processedEvent = processEvent(event, meta_or);
+    expect(processedEvent).toBeUndefined();
 });

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -1,5 +1,7 @@
 import { expect, test, describe } from "@jest/globals";
-import { createEvent } from "@posthog/plugin-scaffold/test/utils";
+import { createEvent } from "@posthog/plugin-scaffold/dist/test/utils";
+import { PluginEvent } from "@posthog/plugin-scaffold";
+
 import { Filter, PluginMeta, processEvent, setupPlugin } from "./main";
 
 const filters: Filter[] = [
@@ -35,7 +37,7 @@ test("Event satisfies all conditions and passes", () => {
             foo: 20,
             bar: true,
         },
-    });
+    }) as unknown as PluginEvent;
     const processedEvent = processEvent(event, meta);
     expect(processedEvent).toEqual(event);
 });
@@ -48,7 +50,7 @@ test("Event does not satisfy one condition and is dropped", () => {
             foo: 20,
             bar: true,
         },
-    });
+    }) as unknown as PluginEvent;
     const processedEvent = processEvent(event, meta);
     expect(processedEvent).toBeUndefined();
 });
@@ -61,7 +63,7 @@ test("Event does not satisfy any condition and is dropped", () => {
             foo: 5,
             bar: false,
         },
-    });
+    }) as unknown as PluginEvent;
     const processedEvent = processEvent(event, meta);
     expect(processedEvent).toBeUndefined();
 });
@@ -74,7 +76,7 @@ test("Event is marked to be dropped is dropped", () => {
             foo: 20,
             bar: true,
         },
-    });
+    }) as unknown as PluginEvent;
     const processedEvent = processEvent(event, meta);
     expect(processedEvent).toBeUndefined();
 });
@@ -87,7 +89,7 @@ test("Event is marked to be dropped when a property is undefined", () => {
             foo: 20,
             bar: true,
         },
-    });
+    }) as unknown as PluginEvent;
     const processedEvent = processEvent(event, meta);
     expect(processedEvent).toBeUndefined();
 });
@@ -100,7 +102,7 @@ test("Event is marked to be dropped when a property is undefined but keepUndefin
             foo: 20,
             bar: true,
         },
-    });
+    }) as unknown as PluginEvent;
     const processedEvent = processEvent(event, {
         global: { ...meta.global, keepUndefinedProperties: true },
     } as PluginMeta);
@@ -154,7 +156,7 @@ describe("empty filters", () => {
                 foo: 20,
                 bar: true,
             },
-        });
+        }) as unknown as PluginEvent;
         const processedEvent = processEvent(event, meta_no_filters);
         expect(processedEvent).toEqual(event);
     });
@@ -167,7 +169,7 @@ describe("empty filters", () => {
                 foo: 20,
                 bar: true,
             },
-        });
+        }) as unknown as PluginEvent;
         const processedEvent = processEvent(event, meta_no_filters);
         expect(processedEvent).toBeUndefined();
     });
@@ -231,7 +233,7 @@ test("Event satisfies at least one filter group and passes", () => {
             foo: 5,
             bar: true,
         },
-    });
+    }) as unknown as PluginEvent;
     const processedEvent = processEvent(event, meta_or);
     expect(processedEvent).toEqual(event);
 });
@@ -244,7 +246,7 @@ test("Event satisfies no filter groups and is dropped", () => {
             foo: 5,
             bar: false,
         },
-    });
+    }) as unknown as PluginEvent;
     const processedEvent = processEvent(event, meta_or);
     expect(processedEvent).toBeUndefined();
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,8 +7,7 @@ export interface Filter {
   value: string | number | boolean;
 }
 
-export interface PluginMeta
-  extends Meta<{
+export type PluginMeta = Meta<{
     config: {
       eventsToDrop?: string;
       keepUndefinedProperties?: "Yes" | "No";
@@ -21,91 +20,91 @@ export interface PluginMeta
     attachments: {
       filters?: PluginAttachment;
     };
-  }> {}
+  }>
 
 const operations: Record<
   Filter["type"],
   Record<string, (a: any, b: any) => boolean>
 > = {
-  string: {
-    is: (a, b) => a === b,
-    is_not: (a, b) => a !== b,
-    contains: (a, b) => a.includes(b),
-    not_contains: (a, b) => !a.includes(b),
-    regex: (a, b) => new RegExp(b).test(a),
-    not_regex: (a, b) => !new RegExp(b).test(a),
-  },
-  number: {
-    gt: (a, b) => a > b,
-    lt: (a, b) => a < b,
-    gte: (a, b) => a >= b,
-    lte: (a, b) => a <= b,
-    eq: (a, b) => a === b,
-    neq: (a, b) => a !== b,
-  },
-  boolean: {
-    is: (a, b) => a === b,
-    is_not: (a, b) => a !== b,
-  },
+    string: {
+        is: (a, b) => a === b,
+        is_not: (a, b) => a !== b,
+        contains: (a, b) => a.includes(b),
+        not_contains: (a, b) => !a.includes(b),
+        regex: (a, b) => new RegExp(b).test(a),
+        not_regex: (a, b) => !new RegExp(b).test(a),
+    },
+    number: {
+        gt: (a, b) => a > b,
+        lt: (a, b) => a < b,
+        gte: (a, b) => a >= b,
+        lte: (a, b) => a <= b,
+        eq: (a, b) => a === b,
+        neq: (a, b) => a !== b,
+    },
+    boolean: {
+        is: (a, b) => a === b,
+        is_not: (a, b) => a !== b,
+    },
 };
 
 export function setupPlugin({ global, config, attachments }: PluginMeta) {
-  if (attachments.filters) {
-    try {
-      // Parse the filters from the attachment
-      const filterGroups = JSON.parse(attachments.filters.contents) as Filter[][];
-      if (!filterGroups) throw new Error("No filters found");
+    if (attachments.filters) {
+        try {
+            // Parse the filters from the attachment
+            const filterGroups = JSON.parse(attachments.filters.contents) as Filter[][];
+            if (!filterGroups) throw new Error("No filters found");
 
-      // Check if the filters are valid
-      for (const filters of filterGroups) {
-        for (const filter of filters) {
-          if (!operations[filter.type][filter.operator]) {
-            throw new Error(
-              `Invalid operator "${filter.operator}" for type "${filter.type}" in filter for "${filter.property}"`
-            );
-          }
+            // Check if the filters are valid
+            for (const filters of filterGroups) {
+                for (const filter of filters) {
+                    if (!operations[filter.type][filter.operator]) {
+                        throw new Error(
+                            `Invalid operator "${filter.operator}" for type "${filter.type}" in filter for "${filter.property}"`
+                        );
+                    }
+                }
+            }
+            // Save the filters to the global object
+            global.filters = filterGroups;
+        } catch (err) {
+            throw new Error("Could not parse filters attachment: " + err.message);
         }
-      }
-      // Save the filters to the global object
-      global.filters = filterGroups;
-    } catch (err) {
-      throw new Error("Could not parse filters attachment: " + err.message);
+    } else {
+        global.filters = [];
     }
-  } else {
-    global.filters = [];
-  }
-  global.eventsToDrop =
+    global.eventsToDrop =
     config?.eventsToDrop?.split(",")?.map((event) => event.trim()) || [];
 
-  global.keepUndefinedProperties = config.keepUndefinedProperties === "Yes";
+    global.keepUndefinedProperties = config.keepUndefinedProperties === "Yes";
 }
 
 export function processEvent(
-  event: PluginEvent,
-  meta: PluginMeta
+    event: PluginEvent,
+    meta: PluginMeta
 ): PluginEvent {
-  if (!event.properties) return event;
-  const { filters, eventsToDrop, keepUndefinedProperties } = meta.global;
+    if (!event.properties) return event;
+    const { filters, eventsToDrop, keepUndefinedProperties } = meta.global;
 
-  // If the event name matches, we drop the event
-  if (eventsToDrop.some((e) => event.event === e)) {
-    return undefined;
-  }
+    // If the event name matches, we drop the event
+    if (eventsToDrop.some((e) => event.event === e)) {
+        return undefined;
+    }
 
-  // Check if the event satisfies any of the filter groups (OR logic between groups)
-  const keepEvent = filters.some((filterGroup) => 
+    // Check if the event satisfies any of the filter groups (OR logic between groups)
+    const keepEvent = filters.some((filterGroup) => 
     // Check if all filters in the group are satisfied (AND logic within group)
-    filterGroup.every((filter) => {
-      const value = event.properties[filter.property];
-      if (value === undefined) return keepUndefinedProperties;
+        filterGroup.every((filter) => {
+            const value = event.properties[filter.property];
+            if (value === undefined) return keepUndefinedProperties;
 
-      const operation = operations[filter.type][filter.operator];
-      if (!operation) throw new Error(`Invalid operator ${filter.operator}`);
+            const operation = operations[filter.type][filter.operator];
+            if (!operation) throw new Error(`Invalid operator ${filter.operator}`);
 
-      return operation(value, filter.value);
-    })
-  );
+            return operation(value, filter.value);
+        })
+    );
 
-  // If should keep the event, return it, else return undefined
-  return keepEvent ? event : undefined;
+    // If should keep the event, return it, else return undefined
+    return keepEvent ? event : undefined;
 }


### PR DESCRIPTION
This PR adds support for using OR between groups of AND conditions, allowing for more complex filter configurations.

The change here modifies `Filter[]` to `Filter[][]`, where each inner group represents an AND condition, and OR is applied between these groups.

Our use case involves filtering for `run.created` entries that do not have the `count` property. This can only be modeled as either "not `run.created`" OR "has `count` property."

Fixes: https://github.com/PostHog/posthog-filter-out-plugin/issues/6

**Note: I couldn't run the tests offline**
**Note: The lint was failing on the existing code, I ran lint fix there too**